### PR TITLE
Feature/add mocha

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ before_install:
 script:
   - npm run test-react
   - npm run test-truffle
+  - echo "{\"address\":\"0x0000000000000000000000000000000000000000\"}" > $TRAVIS_BUILD_DIR/voting-dapp/client/src/managerContract.config.json
   - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: node_js
 node_js:
   - "10.2.1"
-cache:
-  directories:
-    - $(npm config get prefix)/bin/truffle
 before_install:
   - npm i -g npm@6.4.0
   - npm install -g truffle@v5.0.0
 script:
   - npm run test-react
-  - npm run test-truffle
-  - echo "{\"address\":\"0x0000000000000000000000000000000000000000\"}" > $TRAVIS_BUILD_DIR/voting-dapp/client/src/managerContract.config.json
+  - echo "{\"address\":\"0x0000000000000000000000000000000000000000\"}" > $TRAVIS_BUILD_DIR/client/src/managerContract.config.json
   - npm run build
+  - npm run test-truffle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: node_js
 node_js:
   - "10.2.1"
+env:
+  - JOB=test-react
+  - JOB=build
+  - JOB=test-truffle
 before_install:
   - npm i -g npm@6.4.0
   - npm install -g truffle@v5.0.0
 script:
-  - npm run test-react
   - echo "{\"address\":\"0x0000000000000000000000000000000000000000\"}" > $TRAVIS_BUILD_DIR/client/src/managerContract.config.json
-  - npm run build
-  - npm run test-truffle
+  - npm run $JOB

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ node_js:
 before_install:
   - npm i -g npm@6.4.0
   - npm install -g truffle@v5.0.0
+script:
+  - npm run test-react
+  - npm run test-truffle
+  - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - "10.2.1"
+cache:
+  directories:
+    - $(npm config get prefix)/bin/truffle
 before_install:
   - npm i -g npm@6.4.0
   - npm install -g truffle@v5.0.0

--- a/client/src/components/about/AboutPage.spec.tsx
+++ b/client/src/components/about/AboutPage.spec.tsx
@@ -1,0 +1,13 @@
+import { expect } from "chai";
+import { configure } from "enzyme";
+
+/* Repeat those 2 lines in every *.spec.ts file */
+import Adapter from "enzyme-adapter-react-16";
+configure({ adapter: new Adapter() });
+/* -------------------------------------------- */
+
+describe("It's not even a test, dummy", () => {
+  it("does nothing", () => {
+    expect(true).to.be.true;
+  });
+});

--- a/client/src/components/common/Header.spec.tsx
+++ b/client/src/components/common/Header.spec.tsx
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+import { configure, shallow } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import React from "react";
+
+import Header from "./Header";
+
+configure({ adapter: new Adapter() });
+
+describe("<Header/>", () => {
+  it("should have 4 NavItems", () => {
+    const header = shallow(<Header block={0} />);
+    expect(header.find("NavItem")).to.have.lengthOf(4);
+  });
+
+  context("when prop 'block' is equal to 0", () => {
+    it("Nav should have 0 disabled items", () => {
+      const header = shallow(<Header block={0} />);
+      expect(
+        header
+          .find("Nav")
+          .children()
+          .filter("[disabled=true]")
+      ).to.have.lengthOf(0);
+    });
+  });
+
+  context("when prop 'block' is in range to [1-3]", () => {
+    it("has Nav with 2 disabled items", () => {
+      for (let i = 1; i <= 3; i++) {
+        const header = shallow(<Header block={i} />);
+        expect(
+          header
+            .find("Nav")
+            .children()
+            .filter("[disabled=true]")
+        ).to.have.lengthOf(2);
+      }
+    });
+
+    it("has '/createvote' and '/listvotings' links disabled", () => {
+      for (let i = 1; i <= 3; i++) {
+        const header = shallow(<Header block={i} />);
+        expect(header.find("[to='/createvote']").prop("disabled")).to.be.true;
+        expect(header.find("[to='/listvotings']").prop("disabled")).to.be.true;
+      }
+    });
+
+    it("has index page and '/about' link enabled", () => {
+      for (let i = 1; i <= 3; i++) {
+        const header = shallow(<Header block={i} />);
+        expect(header.find("[to='/']").prop("disabled")).to.be.false;
+        expect(header.find("[to='/about']").prop("disabled")).to.be.false;
+      }
+    });
+  });
+
+  context("when prop 'block' is equal to 4", () => {
+    it("Nav should have 4 disabled items", () => {
+      const header = shallow(<Header block={4} />);
+      expect(
+        header
+          .find("Nav")
+          .children()
+          .filter("[disabled=true]")
+      ).to.have.lengthOf(4);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -918,8 +918,23 @@
         "@types/chai": {
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
-            "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+            "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA=="
+        },
+        "@types/cheerio": {
+            "version": "0.22.10",
+            "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.10.tgz",
+            "integrity": "sha512-fOM/Jhv51iyugY7KOBZz2ThfT1gwvsGCfWxpLpZDgkGjpEO4Le9cld07OdskikLjDUQJ43dzDaVRSFwQlpdqVg==",
             "dev": true
+        },
+        "@types/enzyme": {
+            "version": "3.1.15",
+            "resolved": "https://registry.npmjs.org/@types/enzyme/-/enzyme-3.1.15.tgz",
+            "integrity": "sha512-6b4JWgV+FNec1c4+8HauGbXg5gRc1oQK93t2+4W+bHjG/PzO+iPvagY6d6bXAZ+t+ps51Zb2F9LQ4vl0S0Epog==",
+            "dev": true,
+            "requires": {
+                "@types/cheerio": "*",
+                "@types/react": "*"
+            }
         },
         "@types/history": {
             "version": "4.7.2",
@@ -939,8 +954,7 @@
         "@types/mocha": {
             "version": "5.2.5",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
-            "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
-            "dev": true
+            "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww=="
         },
         "@types/node": {
             "version": "10.12.12",
@@ -1623,14 +1637,6 @@
                 }
             }
         },
-        "append-transform": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-            "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
-            "requires": {
-                "default-require-extensions": "^1.0.0"
-            }
-        },
         "aproba": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1732,6 +1738,17 @@
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
             "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
         },
+        "array.prototype.flat": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
+            "integrity": "sha512-rVqIs330nLJvfC7JqYvEWwqVr5QjYF1ib02i3YJtR/fICO6527Tjpc/e4Mvmxh3GIePPreRXMdaGyC99YphWEw==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.10.0",
+                "function-bind": "^1.1.1"
+            }
+        },
         "arrify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -1806,19 +1823,6 @@
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
             "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
-        },
-        "astral-regex": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
-        },
-        "async": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-            "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-            "requires": {
-                "lodash": "^4.17.10"
-            }
         },
         "async-each": {
             "version": "1.0.1",
@@ -2299,18 +2303,9 @@
             "dependencies": {
                 "jsesc": {
                     "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
                     "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
                 }
-            }
-        },
-        "babel-helpers": {
-            "version": "6.24.1",
-            "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-            "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-            "requires": {
-                "babel-runtime": "^6.22.0",
-                "babel-template": "^6.24.1"
             }
         },
         "babel-jest": {
@@ -2351,7 +2346,7 @@
         },
         "babel-plugin-istanbul": {
             "version": "4.1.6",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+            "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
             "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
             "requires": {
                 "babel-plugin-syntax-object-rest-spread": "^6.13.0",
@@ -2548,61 +2543,6 @@
                     "requires": {
                         "regenerator-runtime": "^0.12.0"
                     }
-                }
-            }
-        },
-        "babel-register": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-            "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-            "requires": {
-                "babel-core": "^6.26.0",
-                "babel-runtime": "^6.26.0",
-                "core-js": "^2.5.0",
-                "home-or-tmp": "^2.0.0",
-                "lodash": "^4.17.4",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.4.15"
-            },
-            "dependencies": {
-                "babel-core": {
-                    "version": "6.26.3",
-                    "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-                    "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-                    "requires": {
-                        "babel-code-frame": "^6.26.0",
-                        "babel-generator": "^6.26.0",
-                        "babel-helpers": "^6.24.1",
-                        "babel-messages": "^6.23.0",
-                        "babel-register": "^6.26.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-template": "^6.26.0",
-                        "babel-traverse": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "convert-source-map": "^1.5.1",
-                        "debug": "^2.6.9",
-                        "json5": "^0.5.1",
-                        "lodash": "^4.17.4",
-                        "minimatch": "^3.0.4",
-                        "path-is-absolute": "^1.0.1",
-                        "private": "^0.1.8",
-                        "slash": "^1.0.0",
-                        "source-map": "^0.5.7"
-                    }
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -2922,7 +2862,7 @@
             "dependencies": {
                 "resolve": {
                     "version": "1.1.7",
-                    "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                     "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
                 }
             }
@@ -3022,14 +2962,6 @@
                 "caniuse-lite": "^1.0.30000912",
                 "electron-to-chromium": "^1.3.86",
                 "node-releases": "^1.0.5"
-            }
-        },
-        "bser": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-            "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
-            "requires": {
-                "node-int64": "^0.4.0"
             }
         },
         "buffer": {
@@ -3211,14 +3143,6 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000918.tgz",
             "integrity": "sha512-CAZ9QXGViBvhHnmIHhsTPSWFBujDaelKnUj7wwImbyQRxmXynYqKGi3UaZTSz9MoVh+1EVxOS/DFIkrJYgR3aw=="
         },
-        "capture-exit": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
-            "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
-            "requires": {
-                "rsvp": "^3.3.3"
-            }
-        },
         "case-sensitive-paths-webpack-plugin": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.2.tgz",
@@ -3268,6 +3192,87 @@
             "version": "7.4.0",
             "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.4.0.tgz",
             "integrity": "sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg=="
+        },
+        "cheerio": {
+            "version": "1.0.0-rc.2",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+            "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+            "dev": true,
+            "requires": {
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
+            },
+            "dependencies": {
+                "css-select": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+                    "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+                    "dev": true,
+                    "requires": {
+                        "boolbase": "~1.0.0",
+                        "css-what": "2.1",
+                        "domutils": "1.5.1",
+                        "nth-check": "~1.0.1"
+                    }
+                },
+                "domhandler": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+                    "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+                    "dev": true,
+                    "requires": {
+                        "domelementtype": "1"
+                    }
+                },
+                "domutils": {
+                    "version": "1.5.1",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                    "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+                    "dev": true,
+                    "requires": {
+                        "dom-serializer": "0",
+                        "domelementtype": "1"
+                    }
+                },
+                "htmlparser2": {
+                    "version": "3.10.0",
+                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
+                    "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+                    "dev": true,
+                    "requires": {
+                        "domelementtype": "^1.3.0",
+                        "domhandler": "^2.3.0",
+                        "domutils": "^1.5.1",
+                        "entities": "^1.1.1",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^3.0.6"
+                    }
+                },
+                "parse5": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+                    "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+                    "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "chokidar": {
             "version": "2.0.4",
@@ -3389,7 +3394,8 @@
         "ci-info": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
+            "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+            "dev": true
         },
         "cipher-base": {
             "version": "1.0.4",
@@ -3495,11 +3501,6 @@
                 "lazy-cache": "^1.0.3",
                 "shallow-clone": "^0.1.2"
             }
-        },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "coa": {
             "version": "2.0.2",
@@ -4259,7 +4260,8 @@
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
         },
         "decimal.js-light": {
             "version": "2.5.0",
@@ -4404,14 +4406,6 @@
                 }
             }
         },
-        "default-require-extensions": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-            "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
-            "requires": {
-                "strip-bom": "^2.0.0"
-            }
-        },
         "define-properties": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -4533,11 +4527,6 @@
                 "repeating": "^2.0.0"
             }
         },
-        "detect-newline": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-            "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
-        },
         "detect-node": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
@@ -4570,7 +4559,8 @@
         "diff": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
         },
         "diffie-hellman": {
             "version": "5.0.3",
@@ -4605,6 +4595,12 @@
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
                 }
             }
+        },
+        "discontinuous-range": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+            "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+            "dev": true
         },
         "dns-equal": {
             "version": "1.0.0",
@@ -4827,6 +4823,60 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
             "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        },
+        "enzyme": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.8.0.tgz",
+            "integrity": "sha512-bfsWo5nHyZm1O1vnIsbwdfhU989jk+squU9NKvB+Puwo5j6/Wg9pN5CO0YJelm98Dao3NPjkDZk+vvgwpMwYxw==",
+            "dev": true,
+            "requires": {
+                "array.prototype.flat": "^1.2.1",
+                "cheerio": "^1.0.0-rc.2",
+                "function.prototype.name": "^1.1.0",
+                "has": "^1.0.3",
+                "is-boolean-object": "^1.0.0",
+                "is-callable": "^1.1.4",
+                "is-number-object": "^1.0.3",
+                "is-string": "^1.0.4",
+                "is-subset": "^0.1.1",
+                "lodash.escape": "^4.0.1",
+                "lodash.isequal": "^4.5.0",
+                "object-inspect": "^1.6.0",
+                "object-is": "^1.0.1",
+                "object.assign": "^4.1.0",
+                "object.entries": "^1.0.4",
+                "object.values": "^1.0.4",
+                "raf": "^3.4.0",
+                "rst-selector-parser": "^2.2.3",
+                "string.prototype.trim": "^1.1.2"
+            }
+        },
+        "enzyme-adapter-react-16": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.7.1.tgz",
+            "integrity": "sha512-OQXKgfHWyHN3sFu2nKj3mhgRcqIPIJX6aOzq5AHVFES4R9Dw/vCBZFMPyaG81g2AZ5DogVh39P3MMNUbqNLTcw==",
+            "dev": true,
+            "requires": {
+                "enzyme-adapter-utils": "^1.9.0",
+                "function.prototype.name": "^1.1.0",
+                "object.assign": "^4.1.0",
+                "object.values": "^1.0.4",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.6.1",
+                "react-test-renderer": "^16.0.0-0"
+            }
+        },
+        "enzyme-adapter-utils": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.9.1.tgz",
+            "integrity": "sha512-LWc88BbKztLXlpRf5Ba/pSMJRaNezAwZBvis3N/IuB65ltZEh2E2obWU9B36pAbw7rORYeBUuqc79OL17ZzN1A==",
+            "dev": true,
+            "requires": {
+                "function.prototype.name": "^1.1.0",
+                "object.assign": "^4.1.0",
+                "prop-types": "^15.6.2",
+                "semver": "^5.6.0"
+            }
         },
         "errno": {
             "version": "0.1.7",
@@ -5432,45 +5482,6 @@
                 "safe-buffer": "^5.1.1"
             }
         },
-        "exec-sh": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
-            "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
-            "requires": {
-                "merge": "^1.2.0"
-            }
-        },
-        "execa": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-            "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-            },
-            "dependencies": {
-                "cross-spawn": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-                    "requires": {
-                        "lru-cache": "^4.0.1",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                }
-            }
-        },
-        "exit": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw="
-        },
         "expand-brackets": {
             "version": "0.1.5",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -5493,19 +5504,6 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "requires": {
                 "homedir-polyfill": "^1.0.1"
-            }
-        },
-        "expect": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-23.6.0.tgz",
-            "integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
-            "requires": {
-                "ansi-styles": "^3.2.0",
-                "jest-diff": "^23.6.0",
-                "jest-get-type": "^22.1.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0"
             }
         },
         "express": {
@@ -5948,14 +5946,6 @@
                 "websocket-driver": ">=0.5.1"
             }
         },
-        "fb-watchman": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-            "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-            "requires": {
-                "bser": "^2.0.0"
-            }
-        },
         "fbjs": {
             "version": "0.8.17",
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
@@ -6025,15 +6015,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
             "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-        },
-        "fileset": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-            "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-            "requires": {
-                "glob": "^7.0.3",
-                "minimatch": "^3.0.3"
-            }
         },
         "filesize": {
             "version": "3.6.1",
@@ -6615,13 +6596,11 @@
                 },
                 "balanced-match": {
                     "version": "1.0.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -6634,18 +6613,15 @@
                 },
                 "code-point-at": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -6748,8 +6724,7 @@
                 },
                 "inherits": {
                     "version": "2.0.3",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -6759,7 +6734,6 @@
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -6772,7 +6746,6 @@
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -6872,8 +6845,7 @@
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
-                    "bundled": true,
-                    "optional": true
+                    "bundled": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -6883,7 +6855,6 @@
                 "once": {
                     "version": "1.4.0",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -6989,7 +6960,6 @@
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -7068,6 +7038,17 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "function.prototype.name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+            "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "is-callable": "^1.1.3"
+            }
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -7261,11 +7242,6 @@
             "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
             "dev": true
         },
-        "growly": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
-            "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
-        },
         "gzip-size": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
@@ -7334,24 +7310,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
             "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
-        },
-        "handlebars": {
-            "version": "4.0.12",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
-            "integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
-            "requires": {
-                "async": "^2.5.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                }
-            }
         },
         "har-schema": {
             "version": "2.0.0",
@@ -7517,15 +7475,6 @@
             "version": "2.5.5",
             "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
             "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        },
-        "home-or-tmp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-            "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-            "requires": {
-                "os-homedir": "^1.0.0",
-                "os-tmpdir": "^1.0.1"
-            }
         },
         "homedir-polyfill": {
             "version": "1.0.1",
@@ -8198,15 +8147,6 @@
                 "resolve-from": "^3.0.0"
             }
         },
-        "import-local": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-            "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-            "requires": {
-                "pkg-dir": "^2.0.0",
-                "resolve-cwd": "^2.0.0"
-            }
-        },
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -8300,11 +8240,6 @@
                 "loose-envify": "^1.0.0"
             }
         },
-        "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
         "ip": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
@@ -8346,6 +8281,12 @@
                 "binary-extensions": "^1.0.0"
             }
         },
+        "is-boolean-object": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+            "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+            "dev": true
+        },
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -8368,6 +8309,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
             "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+            "dev": true,
             "requires": {
                 "ci-info": "^1.5.0"
             }
@@ -8461,11 +8403,6 @@
             "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
             "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
         },
-        "is-generator-fn": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
-            "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go="
-        },
         "is-glob": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
@@ -8491,6 +8428,12 @@
             "requires": {
                 "kind-of": "^3.0.2"
             }
+        },
+        "is-number-object": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
+            "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+            "dev": true
         },
         "is-obj": {
             "version": "1.0.1",
@@ -8584,6 +8527,18 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
             "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
+        "is-string": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+            "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+            "dev": true
+        },
+        "is-subset": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+            "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
+            "dev": true
+        },
         "is-svg": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-3.0.0.tgz",
@@ -8657,36 +8612,10 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
-        "istanbul-api": {
-            "version": "1.3.7",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
-            "integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
-            "requires": {
-                "async": "^2.1.4",
-                "fileset": "^2.0.2",
-                "istanbul-lib-coverage": "^1.2.1",
-                "istanbul-lib-hook": "^1.2.2",
-                "istanbul-lib-instrument": "^1.10.2",
-                "istanbul-lib-report": "^1.1.5",
-                "istanbul-lib-source-maps": "^1.2.6",
-                "istanbul-reports": "^1.5.1",
-                "js-yaml": "^3.7.0",
-                "mkdirp": "^0.5.1",
-                "once": "^1.4.0"
-            }
-        },
         "istanbul-lib-coverage": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
             "integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ=="
-        },
-        "istanbul-lib-hook": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
-            "integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
-            "requires": {
-                "append-transform": "^0.4.0"
-            }
         },
         "istanbul-lib-instrument": {
             "version": "1.10.2",
@@ -8702,52 +8631,6 @@
                 "semver": "^5.3.0"
             }
         },
-        "istanbul-lib-report": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
-            "integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
-            "requires": {
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "path-parse": "^1.0.5",
-                "supports-color": "^3.1.2"
-            },
-            "dependencies": {
-                "has-flag": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-                    "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-                },
-                "supports-color": {
-                    "version": "3.2.3",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-                    "requires": {
-                        "has-flag": "^1.0.0"
-                    }
-                }
-            }
-        },
-        "istanbul-lib-source-maps": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
-            "integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
-            "requires": {
-                "debug": "^3.1.0",
-                "istanbul-lib-coverage": "^1.2.1",
-                "mkdirp": "^0.5.1",
-                "rimraf": "^2.6.1",
-                "source-map": "^0.5.3"
-            }
-        },
-        "istanbul-reports": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
-            "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
-            "requires": {
-                "handlebars": "^4.0.3"
-            }
-        },
         "isurl": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
@@ -8757,336 +8640,10 @@
                 "is-object": "^1.0.1"
             }
         },
-        "jest": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest/-/jest-23.6.0.tgz",
-            "integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
-            "requires": {
-                "import-local": "^1.0.0",
-                "jest-cli": "^23.6.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                },
-                "jest-cli": {
-                    "version": "23.6.0",
-                    "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
-                    "integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
-                    "requires": {
-                        "ansi-escapes": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "exit": "^0.1.2",
-                        "glob": "^7.1.2",
-                        "graceful-fs": "^4.1.11",
-                        "import-local": "^1.0.0",
-                        "is-ci": "^1.0.10",
-                        "istanbul-api": "^1.3.1",
-                        "istanbul-lib-coverage": "^1.2.0",
-                        "istanbul-lib-instrument": "^1.10.1",
-                        "istanbul-lib-source-maps": "^1.2.4",
-                        "jest-changed-files": "^23.4.2",
-                        "jest-config": "^23.6.0",
-                        "jest-environment-jsdom": "^23.4.0",
-                        "jest-get-type": "^22.1.0",
-                        "jest-haste-map": "^23.6.0",
-                        "jest-message-util": "^23.4.0",
-                        "jest-regex-util": "^23.3.0",
-                        "jest-resolve-dependencies": "^23.6.0",
-                        "jest-runner": "^23.6.0",
-                        "jest-runtime": "^23.6.0",
-                        "jest-snapshot": "^23.6.0",
-                        "jest-util": "^23.4.0",
-                        "jest-validate": "^23.6.0",
-                        "jest-watcher": "^23.4.0",
-                        "jest-worker": "^23.2.0",
-                        "micromatch": "^2.3.11",
-                        "node-notifier": "^5.2.1",
-                        "prompts": "^0.1.9",
-                        "realpath-native": "^1.0.0",
-                        "rimraf": "^2.5.4",
-                        "slash": "^1.0.0",
-                        "string-length": "^2.0.0",
-                        "strip-ansi": "^4.0.0",
-                        "which": "^1.2.12",
-                        "yargs": "^11.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "jest-changed-files": {
-            "version": "23.4.2",
-            "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.4.2.tgz",
-            "integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
-            "requires": {
-                "throat": "^4.0.0"
-            }
-        },
-        "jest-config": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.6.0.tgz",
-            "integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
-            "requires": {
-                "babel-core": "^6.0.0",
-                "babel-jest": "^23.6.0",
-                "chalk": "^2.0.1",
-                "glob": "^7.1.1",
-                "jest-environment-jsdom": "^23.4.0",
-                "jest-environment-node": "^23.4.0",
-                "jest-get-type": "^22.1.0",
-                "jest-jasmine2": "^23.6.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "micromatch": "^2.3.11",
-                "pretty-format": "^23.6.0"
-            },
-            "dependencies": {
-                "babel-core": {
-                    "version": "6.26.3",
-                    "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-                    "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-                    "requires": {
-                        "babel-code-frame": "^6.26.0",
-                        "babel-generator": "^6.26.0",
-                        "babel-helpers": "^6.24.1",
-                        "babel-messages": "^6.23.0",
-                        "babel-register": "^6.26.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-template": "^6.26.0",
-                        "babel-traverse": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "convert-source-map": "^1.5.1",
-                        "debug": "^2.6.9",
-                        "json5": "^0.5.1",
-                        "lodash": "^4.17.4",
-                        "minimatch": "^3.0.4",
-                        "path-is-absolute": "^1.0.1",
-                        "private": "^0.1.8",
-                        "slash": "^1.0.0",
-                        "source-map": "^0.5.7"
-                    }
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                }
-            }
-        },
-        "jest-diff": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.6.0.tgz",
-            "integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
-            "requires": {
-                "chalk": "^2.0.1",
-                "diff": "^3.2.0",
-                "jest-get-type": "^22.1.0",
-                "pretty-format": "^23.6.0"
-            }
-        },
-        "jest-docblock": {
-            "version": "23.2.0",
-            "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
-            "integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
-            "requires": {
-                "detect-newline": "^2.1.0"
-            }
-        },
-        "jest-each": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.6.0.tgz",
-            "integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
-            "requires": {
-                "chalk": "^2.0.1",
-                "pretty-format": "^23.6.0"
-            }
-        },
-        "jest-environment-jsdom": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz",
-            "integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
-            "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0",
-                "jsdom": "^11.5.1"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "5.7.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-                    "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
-                },
-                "jsdom": {
-                    "version": "11.12.0",
-                    "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
-                    "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
-                    "requires": {
-                        "abab": "^2.0.0",
-                        "acorn": "^5.5.3",
-                        "acorn-globals": "^4.1.0",
-                        "array-equal": "^1.0.0",
-                        "cssom": ">= 0.3.2 < 0.4.0",
-                        "cssstyle": "^1.0.0",
-                        "data-urls": "^1.0.0",
-                        "domexception": "^1.0.1",
-                        "escodegen": "^1.9.1",
-                        "html-encoding-sniffer": "^1.0.2",
-                        "left-pad": "^1.3.0",
-                        "nwsapi": "^2.0.7",
-                        "parse5": "4.0.0",
-                        "pn": "^1.1.0",
-                        "request": "^2.87.0",
-                        "request-promise-native": "^1.0.5",
-                        "sax": "^1.2.4",
-                        "symbol-tree": "^3.2.2",
-                        "tough-cookie": "^2.3.4",
-                        "w3c-hr-time": "^1.0.1",
-                        "webidl-conversions": "^4.0.2",
-                        "whatwg-encoding": "^1.0.3",
-                        "whatwg-mimetype": "^2.1.0",
-                        "whatwg-url": "^6.4.1",
-                        "ws": "^5.2.0",
-                        "xml-name-validator": "^3.0.0"
-                    }
-                },
-                "parse5": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-                    "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
-                },
-                "whatwg-url": {
-                    "version": "6.5.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-                    "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
-                    "requires": {
-                        "lodash.sortby": "^4.7.0",
-                        "tr46": "^1.0.1",
-                        "webidl-conversions": "^4.0.2"
-                    }
-                },
-                "ws": {
-                    "version": "5.2.2",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-                    "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-                    "requires": {
-                        "async-limiter": "~1.0.0"
-                    }
-                }
-            }
-        },
-        "jest-environment-node": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.4.0.tgz",
-            "integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
-            "requires": {
-                "jest-mock": "^23.2.0",
-                "jest-util": "^23.4.0"
-            }
-        },
-        "jest-get-type": {
-            "version": "22.4.3",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-            "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
-        },
-        "jest-haste-map": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.6.0.tgz",
-            "integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
-            "requires": {
-                "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "invariant": "^2.2.4",
-                "jest-docblock": "^23.2.0",
-                "jest-serializer": "^23.0.1",
-                "jest-worker": "^23.2.0",
-                "micromatch": "^2.3.11",
-                "sane": "^2.0.0"
-            }
-        },
-        "jest-jasmine2": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.6.0.tgz",
-            "integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
-            "requires": {
-                "babel-traverse": "^6.0.0",
-                "chalk": "^2.0.1",
-                "co": "^4.6.0",
-                "expect": "^23.6.0",
-                "is-generator-fn": "^1.0.0",
-                "jest-diff": "^23.6.0",
-                "jest-each": "^23.6.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "pretty-format": "^23.6.0"
-            }
-        },
-        "jest-leak-detector": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.6.0.tgz",
-            "integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
-            "requires": {
-                "pretty-format": "^23.6.0"
-            }
-        },
-        "jest-matcher-utils": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",
-            "integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
-            "requires": {
-                "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
-                "pretty-format": "^23.6.0"
-            }
-        },
-        "jest-message-util": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.4.0.tgz",
-            "integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
-            "requires": {
-                "@babel/code-frame": "^7.0.0-beta.35",
-                "chalk": "^2.0.1",
-                "micromatch": "^2.3.11",
-                "slash": "^1.0.0",
-                "stack-utils": "^1.0.1"
-            }
-        },
-        "jest-mock": {
-            "version": "23.2.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
-            "integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ="
-        },
         "jest-pnp-resolver": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.0.1.tgz",
             "integrity": "sha512-kzhvJQp+9k0a/hpvIIzOJgOwfOqmnohdrAMZW2EscH3kxR2VWD7EcPa10cio8EK9V7PcD75bhG1pFnO70zGwSQ=="
-        },
-        "jest-regex-util": {
-            "version": "23.3.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",
-            "integrity": "sha1-X4ZylUfCeFxAAs6qj4Sf6MpHG8U="
         },
         "jest-resolve": {
             "version": "23.6.0",
@@ -9096,198 +8653,6 @@
                 "browser-resolve": "^1.11.3",
                 "chalk": "^2.0.1",
                 "realpath-native": "^1.0.0"
-            }
-        },
-        "jest-resolve-dependencies": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.6.0.tgz",
-            "integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
-            "requires": {
-                "jest-regex-util": "^23.3.0",
-                "jest-snapshot": "^23.6.0"
-            }
-        },
-        "jest-runner": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.6.0.tgz",
-            "integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
-            "requires": {
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^23.6.0",
-                "jest-docblock": "^23.2.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-jasmine2": "^23.6.0",
-                "jest-leak-detector": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-runtime": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-worker": "^23.2.0",
-                "source-map-support": "^0.5.6",
-                "throat": "^4.0.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                },
-                "source-map-support": {
-                    "version": "0.5.9",
-                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-                    "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-                    "requires": {
-                        "buffer-from": "^1.0.0",
-                        "source-map": "^0.6.0"
-                    }
-                }
-            }
-        },
-        "jest-runtime": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.6.0.tgz",
-            "integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
-            "requires": {
-                "babel-core": "^6.0.0",
-                "babel-plugin-istanbul": "^4.1.6",
-                "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
-                "exit": "^0.1.2",
-                "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.11",
-                "jest-config": "^23.6.0",
-                "jest-haste-map": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-regex-util": "^23.3.0",
-                "jest-resolve": "^23.6.0",
-                "jest-snapshot": "^23.6.0",
-                "jest-util": "^23.4.0",
-                "jest-validate": "^23.6.0",
-                "micromatch": "^2.3.11",
-                "realpath-native": "^1.0.0",
-                "slash": "^1.0.0",
-                "strip-bom": "3.0.0",
-                "write-file-atomic": "^2.1.0",
-                "yargs": "^11.0.0"
-            },
-            "dependencies": {
-                "babel-core": {
-                    "version": "6.26.3",
-                    "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-                    "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-                    "requires": {
-                        "babel-code-frame": "^6.26.0",
-                        "babel-generator": "^6.26.0",
-                        "babel-helpers": "^6.24.1",
-                        "babel-messages": "^6.23.0",
-                        "babel-register": "^6.26.0",
-                        "babel-runtime": "^6.26.0",
-                        "babel-template": "^6.26.0",
-                        "babel-traverse": "^6.26.0",
-                        "babel-types": "^6.26.0",
-                        "babylon": "^6.18.0",
-                        "convert-source-map": "^1.5.1",
-                        "debug": "^2.6.9",
-                        "json5": "^0.5.1",
-                        "lodash": "^4.17.4",
-                        "minimatch": "^3.0.4",
-                        "path-is-absolute": "^1.0.1",
-                        "private": "^0.1.8",
-                        "slash": "^1.0.0",
-                        "source-map": "^0.5.7"
-                    }
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                },
-                "strip-bom": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-                }
-            }
-        },
-        "jest-serializer": {
-            "version": "23.0.1",
-            "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
-            "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU="
-        },
-        "jest-snapshot": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.6.0.tgz",
-            "integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
-            "requires": {
-                "babel-types": "^6.0.0",
-                "chalk": "^2.0.1",
-                "jest-diff": "^23.6.0",
-                "jest-matcher-utils": "^23.6.0",
-                "jest-message-util": "^23.4.0",
-                "jest-resolve": "^23.6.0",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^23.6.0",
-                "semver": "^5.5.0"
-            }
-        },
-        "jest-util": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.4.0.tgz",
-            "integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
-            "requires": {
-                "callsites": "^2.0.0",
-                "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.11",
-                "is-ci": "^1.0.10",
-                "jest-message-util": "^23.4.0",
-                "mkdirp": "^0.5.1",
-                "slash": "^1.0.0",
-                "source-map": "^0.6.0"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                }
-            }
-        },
-        "jest-validate": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.6.0.tgz",
-            "integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
-            "requires": {
-                "chalk": "^2.0.1",
-                "jest-get-type": "^22.1.0",
-                "leven": "^2.1.0",
-                "pretty-format": "^23.6.0"
-            }
-        },
-        "jest-watcher": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.4.0.tgz",
-            "integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
-            "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "string-length": "^2.0.0"
-            }
-        },
-        "jest-worker": {
-            "version": "23.2.0",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
-            "integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
-            "requires": {
-                "merge-stream": "^1.0.1"
             }
         },
         "joi": {
@@ -9464,11 +8829,6 @@
                 "is-buffer": "^1.1.5"
             }
         },
-        "kleur": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/kleur/-/kleur-2.0.2.tgz",
-            "integrity": "sha512-77XF9iTllATmG9lSlIv0qdQ2BQ/h9t0bJllHlbvsQ0zUWfU7Yi0S8L5JXzPZgkefIiajLmBJJ4BsMJmqcf7oxQ=="
-        },
         "last-call-webpack-plugin": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
@@ -9482,24 +8842,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
             "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-        },
-        "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "requires": {
-                "invert-kv": "^1.0.0"
-            }
-        },
-        "left-pad": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-            "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
-        },
-        "leven": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
         },
         "levn": {
             "version": "0.3.0",
@@ -9623,6 +8965,24 @@
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
         },
+        "lodash.escape": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+            "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+            "dev": true
+        },
+        "lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "dev": true
+        },
         "lodash.memoize": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9737,14 +9097,6 @@
             "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
             "dev": true
         },
-        "makeerror": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
-            "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
-            "requires": {
-                "tmpl": "1.0.x"
-            }
-        },
         "mamacro": {
             "version": "0.0.3",
             "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
@@ -9802,14 +9154,6 @@
             "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
-        "mem": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-            "requires": {
-                "mimic-fn": "^1.0.0"
-            }
-        },
         "memory-fs": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -9818,11 +9162,6 @@
                 "errno": "^0.1.3",
                 "readable-stream": "^2.0.1"
             }
-        },
-        "merge": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-            "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
         },
         "merge-deep": {
             "version": "3.0.2",
@@ -9838,14 +9177,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
             "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-        },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "requires": {
-                "readable-stream": "^2.0.1"
-            }
         },
         "merge2": {
             "version": "1.2.3",
@@ -10044,7 +9375,7 @@
             "dependencies": {
                 "commander": {
                     "version": "2.15.1",
-                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
                     "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
                     "dev": true
                 },
@@ -10103,6 +9434,12 @@
             "version": "2.22.2",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
             "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+        },
+        "moo": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
+            "integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
+            "dev": true
         },
         "mout": {
             "version": "0.11.1",
@@ -10206,6 +9543,19 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
         },
+        "nearley": {
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
+            "integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+            "dev": true,
+            "requires": {
+                "commander": "^2.19.0",
+                "moo": "^0.4.3",
+                "railroad-diagrams": "^1.0.0",
+                "randexp": "0.4.6",
+                "semver": "^5.4.1"
+            }
+        },
         "negotiator": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
@@ -10249,11 +9599,6 @@
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
             "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
         },
-        "node-int64": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-            "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
-        },
         "node-libs-browser": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
@@ -10291,17 +9636,6 @@
                     "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
                     "dev": true
                 }
-            }
-        },
-        "node-notifier": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
-            "integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
-            "requires": {
-                "growly": "^1.3.0",
-                "semver": "^5.5.0",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
             }
         },
         "node-releases": {
@@ -10423,6 +9757,18 @@
             "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
             "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA=="
         },
+        "object-inspect": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+            "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+            "dev": true
+        },
+        "object-is": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+            "integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=",
+            "dev": true
+        },
         "object-keys": {
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -10445,6 +9791,18 @@
                 "function-bind": "^1.1.1",
                 "has-symbols": "^1.0.0",
                 "object-keys": "^1.0.11"
+            }
+        },
+        "object.entries": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+            "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.12.0",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3"
             }
         },
         "object.getownpropertydescriptors": {
@@ -10534,22 +9892,6 @@
                 "is-wsl": "^1.1.0"
             }
         },
-        "optimist": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-            "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
-            },
-            "dependencies": {
-                "wordwrap": {
-                    "version": "0.0.3",
-                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-                }
-            }
-        },
         "optimize-css-assets-webpack-plugin": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-5.0.1.tgz",
@@ -10585,21 +9927,6 @@
             "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
             "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
             "dev": true
-        },
-        "os-homedir": {
-            "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-        },
-        "os-locale": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-            "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-            "requires": {
-                "execa": "^0.7.0",
-                "lcid": "^1.0.0",
-                "mem": "^1.1.0"
-            }
         },
         "os-tmpdir": {
             "version": "1.0.2",
@@ -12641,22 +11968,6 @@
                 "utila": "~0.4"
             }
         },
-        "pretty-format": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.6.0.tgz",
-            "integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
-            "requires": {
-                "ansi-regex": "^3.0.0",
-                "ansi-styles": "^3.2.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                }
-            }
-        },
         "private": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -12690,15 +12001,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
             "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
-        },
-        "prompts": {
-            "version": "0.1.14",
-            "resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.14.tgz",
-            "integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
-            "requires": {
-                "kleur": "^2.0.1",
-                "sisteransi": "^0.1.1"
-            }
         },
         "prop-types": {
             "version": "15.6.2",
@@ -12832,6 +12134,22 @@
             "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
             "requires": {
                 "performance-now": "^2.1.0"
+            }
+        },
+        "railroad-diagrams": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+            "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+            "dev": true
+        },
+        "randexp": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+            "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+            "dev": true,
+            "requires": {
+                "discontinuous-range": "1.0.0",
+                "ret": "~0.1.10"
             }
         },
         "randomatic": {
@@ -13229,6 +12547,36 @@
                 "prop-types": "^15.6.0",
                 "raf": "^3.4.0",
                 "react-transition-group": "^2.5.0"
+            }
+        },
+        "react-test-renderer": {
+            "version": "16.7.0",
+            "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.7.0.tgz",
+            "integrity": "sha512-tFbhSjknSQ6+ttzmuGdv+SjQfmvGcq3PFKyPItohwhhOBmRoTf1We3Mlt3rJtIn85mjPXOkKV+TaKK4irvk9Yg==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.7.0",
+                "scheduler": "^0.12.0"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "16.7.0",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
+                    "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==",
+                    "dev": true
+                },
+                "scheduler": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
+                    "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                }
             }
         },
         "react-transition-group": {
@@ -13989,10 +13337,15 @@
                 "inherits": "^2.0.1"
             }
         },
-        "rsvp": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-            "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
+        "rst-selector-parser": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+            "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+            "dev": true,
+            "requires": {
+                "lodash.flattendeep": "^4.4.0",
+                "nearley": "^2.7.10"
+            }
         },
         "run-async": {
             "version": "2.3.0",
@@ -14041,285 +13394,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
-        "sane": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
-            "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
-            "requires": {
-                "anymatch": "^2.0.0",
-                "capture-exit": "^1.2.0",
-                "exec-sh": "^0.2.0",
-                "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.3",
-                "micromatch": "^3.1.4",
-                "minimist": "^1.1.1",
-                "walker": "~1.0.5",
-                "watch": "~0.18.0"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-                },
-                "array-unique": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-                },
-                "braces": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-                    "requires": {
-                        "arr-flatten": "^1.1.0",
-                        "array-unique": "^0.3.2",
-                        "extend-shallow": "^2.0.1",
-                        "fill-range": "^4.0.0",
-                        "isobject": "^3.0.1",
-                        "repeat-element": "^1.1.2",
-                        "snapdragon": "^0.8.1",
-                        "snapdragon-node": "^2.0.1",
-                        "split-string": "^3.0.2",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "expand-brackets": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-                    "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-                    "requires": {
-                        "debug": "^2.3.3",
-                        "define-property": "^0.2.5",
-                        "extend-shallow": "^2.0.1",
-                        "posix-character-classes": "^0.1.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "0.2.5",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-                            "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                            "requires": {
-                                "is-descriptor": "^0.1.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        },
-                        "is-accessor-descriptor": {
-                            "version": "0.1.6",
-                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                            "requires": {
-                                "kind-of": "^3.0.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "requires": {
-                                        "is-buffer": "^1.1.5"
-                                    }
-                                }
-                            }
-                        },
-                        "is-data-descriptor": {
-                            "version": "0.1.4",
-                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                            "requires": {
-                                "kind-of": "^3.0.2"
-                            },
-                            "dependencies": {
-                                "kind-of": {
-                                    "version": "3.2.2",
-                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                                    "requires": {
-                                        "is-buffer": "^1.1.5"
-                                    }
-                                }
-                            }
-                        },
-                        "is-descriptor": {
-                            "version": "0.1.6",
-                            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-                            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                            "requires": {
-                                "is-accessor-descriptor": "^0.1.6",
-                                "is-data-descriptor": "^0.1.4",
-                                "kind-of": "^5.0.0"
-                            }
-                        },
-                        "kind-of": {
-                            "version": "5.1.0",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                            "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-                        }
-                    }
-                },
-                "extglob": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-                    "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-                    "requires": {
-                        "array-unique": "^0.3.2",
-                        "define-property": "^1.0.0",
-                        "expand-brackets": "^2.1.4",
-                        "extend-shallow": "^2.0.1",
-                        "fragment-cache": "^0.2.1",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "define-property": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-                            "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                            "requires": {
-                                "is-descriptor": "^1.0.0"
-                            }
-                        },
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "fill-range": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-number": "^3.0.0",
-                        "repeat-string": "^1.6.1",
-                        "to-regex-range": "^2.1.0"
-                    },
-                    "dependencies": {
-                        "extend-shallow": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                            "requires": {
-                                "is-extendable": "^0.1.0"
-                            }
-                        }
-                    }
-                },
-                "is-accessor-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-data-descriptor": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "requires": {
-                        "kind-of": "^6.0.0"
-                    }
-                },
-                "is-descriptor": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
-                    }
-                },
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "requires": {
-                        "kind-of": "^3.0.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "requires": {
-                                "is-buffer": "^1.1.5"
-                            }
-                        }
-                    }
-                },
-                "kind-of": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-                },
-                "micromatch": {
-                    "version": "3.1.10",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-                    "requires": {
-                        "arr-diff": "^4.0.0",
-                        "array-unique": "^0.3.2",
-                        "braces": "^2.3.1",
-                        "define-property": "^2.0.2",
-                        "extend-shallow": "^3.0.2",
-                        "extglob": "^2.0.4",
-                        "fragment-cache": "^0.2.1",
-                        "kind-of": "^6.0.2",
-                        "nanomatch": "^1.2.9",
-                        "object.pick": "^1.3.0",
-                        "regex-not": "^1.0.0",
-                        "snapdragon": "^0.8.1",
-                        "to-regex": "^3.0.2"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-                }
-            }
         },
         "sass-loader": {
             "version": "7.1.0",
@@ -14693,11 +13767,6 @@
                 "jsonify": "~0.0.0"
             }
         },
-        "shellwords": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
-            "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
-        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -14732,11 +13801,6 @@
                     "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
                 }
             }
-        },
-        "sisteransi": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
-            "integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g=="
         },
         "slash": {
             "version": "1.0.0",
@@ -14925,14 +13989,6 @@
                 "urix": "^0.1.0"
             }
         },
-        "source-map-support": {
-            "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-            "requires": {
-                "source-map": "^0.5.6"
-            }
-        },
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
@@ -15063,11 +14119,6 @@
             "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
             "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
         },
-        "stack-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
-        },
         "static-extend": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -15139,30 +14190,6 @@
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
             "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
-        "string-length": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
-            "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
-            "requires": {
-                "astral-regex": "^1.0.0",
-                "strip-ansi": "^4.0.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-                },
-                "strip-ansi": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                    "requires": {
-                        "ansi-regex": "^3.0.0"
-                    }
-                }
-            }
-        },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -15185,6 +14212,17 @@
                         "ansi-regex": "^3.0.0"
                     }
                 }
+            }
+        },
+        "string.prototype.trim": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+            "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.0",
+                "function-bind": "^1.0.2"
             }
         },
         "string_decoder": {
@@ -15619,11 +14657,6 @@
                 "thenify": ">= 3.1.0 < 4"
             }
         },
-        "throat": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-            "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
-        },
         "through": {
             "version": "2.3.8",
             "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -15669,11 +14702,6 @@
             "requires": {
                 "os-tmpdir": "~1.0.2"
             }
-        },
-        "tmpl": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
-            "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE="
         },
         "to-arraybuffer": {
             "version": "1.0.1",
@@ -15765,10 +14793,9 @@
             "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
         },
         "truffle-typings": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/truffle-typings/-/truffle-typings-1.0.5.tgz",
-            "integrity": "sha512-mHkUwuoXBvPMzwg/jtD3cEvAiAa373HZhoDYCA5nLfmtSVKQQvCIEpk74AE4sB+Zl8BquN/oYIRsHKSZi7lCgg==",
-            "dev": true,
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/truffle-typings/-/truffle-typings-1.0.6.tgz",
+            "integrity": "sha512-oGAXGKCpf3FoxFcf000ICJf67eOFvyX3UgIgXucmECleQ4ymD+fdMkK1Qgniwi6HSBVQS6brdUiXHq8Q5A5PPA==",
             "requires": {
                 "@types/chai": "^4.1.4",
                 "@types/mocha": "^5.2.5"
@@ -16479,36 +15506,12 @@
                 "xml-name-validator": "^3.0.0"
             }
         },
-        "walker": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
-            "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
-            "requires": {
-                "makeerror": "1.0.x"
-            }
-        },
         "warning": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
             "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
             "requires": {
                 "loose-envify": "^1.0.0"
-            }
-        },
-        "watch": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
-            "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
-            "requires": {
-                "exec-sh": "^0.2.0",
-                "minimist": "^1.2.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                }
             }
         },
         "watchpack": {
@@ -18062,16 +17065,6 @@
                 "mkdirp": "^0.5.1"
             }
         },
-        "write-file-atomic": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-            "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-            "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
-            }
-        },
         "ws": {
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
@@ -18160,40 +17153,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-        },
-        "yargs": {
-            "version": "11.1.0",
-            "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-            "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
-            "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.1.1",
-                "find-up": "^2.1.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^2.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1",
-                "yargs-parser": "^9.0.2"
-            }
-        },
-        "yargs-parser": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-            "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-            "requires": {
-                "camelcase": "^4.1.0"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-                }
-            }
         },
         "yauzl": {
             "version": "2.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2852,21 +2852,6 @@
             "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
             "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw=="
         },
-        "browser-resolve": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
-            "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-            "requires": {
-                "resolve": "1.1.7"
-            },
-            "dependencies": {
-                "resolve": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-                }
-            }
-        },
         "browser-stdout": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -8640,21 +8625,6 @@
                 "is-object": "^1.0.1"
             }
         },
-        "jest-pnp-resolver": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.0.1.tgz",
-            "integrity": "sha512-kzhvJQp+9k0a/hpvIIzOJgOwfOqmnohdrAMZW2EscH3kxR2VWD7EcPa10cio8EK9V7PcD75bhG1pFnO70zGwSQ=="
-        },
-        "jest-resolve": {
-            "version": "23.6.0",
-            "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.6.0.tgz",
-            "integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
-            "requires": {
-                "browser-resolve": "^1.11.3",
-                "chalk": "^2.0.1",
-                "realpath-native": "^1.0.0"
-            }
-        },
         "joi": {
             "version": "11.4.0",
             "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
@@ -12915,14 +12885,6 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
-            }
-        },
-        "realpath-native": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.2.tgz",
-            "integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
-            "requires": {
-                "util.promisify": "^1.0.0"
             }
         },
         "recharts": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
         "tslint": "tslint --project tsconfig.json",
         "start": "node scripts/start.js",
         "build": "node scripts/build.js",
-        "test-react": "mocha -r ts-node/register client/src/**/*.spec.tsx"
+        "test-react": "mocha -r ts-node/register client/src/**/*.spec.tsx",
+        "test-truffle": "truffle compile && typechain --target truffle './client/src/contracts/*.json' && truffle test"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
         "postinstall": "rm -f node_modules/web3/index.d.ts && npm run generate",
         "test": "truffle compile && typechain --target truffle './client/src/contracts/*.json' && truffle test",
         "test-ganache": "truffle compile && typechain --target truffle './client/src/contracts/*.json' && truffle test --network=ganache",
-        "generate": "truffle compile && typechain --target web3-1.0.0 --outDir './client/src/typed-contracts' './client/src/contracts/*.json' ",
+        "generate": "truffle compile && typechain --target web3-1.0.0 --outDir './client/src/typed-contracts' './client/src/contracts/*.json' && typechain --target truffle './client/src/contracts/*.json'",
         "prettier:write": "prettier --write \"{,!(node_modules|dist|build|coverage)/**/}*.{js,jsx,ts,tsx,json}\"",
         "tslint": "tslint --project tsconfig.json",
         "start": "node scripts/start.js",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "fs-extra": "7.0.0",
         "html-webpack-plugin": "4.0.0-alpha.2",
         "identity-obj-proxy": "3.0.0",
-        "jest": "23.6.0",
         "jest-pnp-resolver": "1.0.1",
         "jest-resolve": "23.6.0",
         "mini-css-extract-plugin": "0.4.3",
@@ -60,6 +59,7 @@
         "sass-loader": "7.1.0",
         "style-loader": "0.23.0",
         "terser-webpack-plugin": "1.1.0",
+        "truffle-typings": "^1.0.6",
         "url-loader": "1.1.1",
         "web3": "^1.0.0-beta.36",
         "webpack-dev-server": "^3.1.14",
@@ -69,6 +69,7 @@
     "devDependencies": {
         "@types/bignumber.js": "^5.0.0",
         "@types/chai": "^4.1.7",
+        "@types/enzyme": "^3.1.15",
         "@types/mocha": "^5.2.5",
         "@types/node": "^10.12.2",
         "@types/react": "^16.7.18",
@@ -79,9 +80,10 @@
         "awesome-typescript-loader": "^5.2.1",
         "babel-plugin-static-fs": "^1.1.0",
         "chai": "^4.2.0",
+        "enzyme": "^3.8.0",
+        "enzyme-adapter-react-16": "^1.7.1",
         "husky": "^1.2.0",
         "mocha": "^5.2.0",
-        "truffle-typings": "^1.0.5",
         "ts-node": "^7.0.1",
         "tslint": "^5.11.0",
         "tslint-config-prettier": "^1.17.0",
@@ -102,7 +104,7 @@
         "tslint": "tslint --project tsconfig.json",
         "start": "node scripts/start.js",
         "build": "node scripts/build.js",
-        "testr": "node scripts/test.js"
+        "test-react": "mocha -r ts-node/register client/src/**/*.spec.tsx"
     },
     "repository": {
         "type": "git",
@@ -131,47 +133,6 @@
         "not ie <= 11",
         "not op_mini all"
     ],
-    "jest": {
-        "collectCoverageFrom": [
-            "src/**/*.{js,jsx,ts,tsx}",
-            "!src/**/*.d.ts"
-        ],
-        "resolver": "jest-pnp-resolver",
-        "setupFiles": [
-            "react-app-polyfill/jsdom"
-        ],
-        "testMatch": [
-            "<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-            "<rootDir>/src/**/?(*.)(spec|test).{js,jsx,ts,tsx}"
-        ],
-        "testEnvironment": "jsdom",
-        "testURL": "http://localhost",
-        "transform": {
-            "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
-            "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
-            "^(?!.*\\.(js|jsx|ts|tsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
-        },
-        "transformIgnorePatterns": [
-            "[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$",
-            "^.+\\.module\\.(css|sass|scss)$"
-        ],
-        "moduleNameMapper": {
-            "^react-native$": "react-native-web",
-            "^.+\\.module\\.(css|sass|scss)$": "identity-obj-proxy"
-        },
-        "moduleFileExtensions": [
-            "web.js",
-            "js",
-            "web.ts",
-            "ts",
-            "web.tsx",
-            "tsx",
-            "json",
-            "web.jsx",
-            "jsx",
-            "node"
-        ]
-    },
     "babel": {
         "presets": [
             "react-app"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,6 @@
         "fs-extra": "7.0.0",
         "html-webpack-plugin": "4.0.0-alpha.2",
         "identity-obj-proxy": "3.0.0",
-        "jest-pnp-resolver": "1.0.1",
-        "jest-resolve": "23.6.0",
         "mini-css-extract-plugin": "0.4.3",
         "moment": "^2.22.2",
         "optimize-css-assets-webpack-plugin": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "start": "node scripts/start.js",
         "build": "node scripts/build.js",
         "test-react": "mocha -r ts-node/register client/src/**/*.spec.tsx",
-        "test-truffle": "truffle compile && typechain --target truffle './client/src/contracts/*.json' && truffle test"
+        "test-truffle": "truffle test"
     },
     "repository": {
         "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,5 @@
         "typeRoots": ["./node_modules/@types", "./types"],
         "types": ["node", "truffle-contracts"]
     },
-    "include": ["./client/src/**/*", "./test/**/*.ts"],
-    "exclude": ["node_modules"]
+    "include": ["./client/src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
         "resolveJsonModule": true,
         "allowSyntheticDefaultImports": true,
         "typeRoots": ["./node_modules/@types", "./types"],
-        "types": ["node", "truffle-contracts"]
+        "types": ["node", "truffle-contracts", "mocha"]
     },
     "include": ["./client/src/**/*"]
 }


### PR DESCRIPTION
To be fair, mocha was already there -- it was used in contract tests.

Changes:
- removed jest and jest related modules
- installed enzyme with necessary plugin
- created `test-react` script for running react tests (of course :suspect: )

Edit: Then, I started to fiddle with Travis CI, so now we have 3 jobs running in parallel:
- react tests
- truffle tests
- building the project