### PR TITLE
add network type check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ client/src/contracts/*
 client/src/typed-contracts/*
 types/*
 
+# App config
+client/src/config.json
+
 # Compiled TS
 client/build/*
 
@@ -83,6 +86,3 @@ typings/
 
 # FuseBox cache
 .fusebox/
-
-# ManagerContract config
-client/src/managerContract.config.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,11 @@
     "solidity.linter": "solhint",
     "editor.formatOnSave": true,
     "typescript.tsdk": "node_modules/typescript/lib",
-    "prettier.eslintIntegration": true
+    "prettier.eslintIntegration": true,
+    "json.schemas": [
+        {
+            "fileMatch": ["/config.json"],
+            "url": "./client/src/config.schema.json"
+        }
+    ]
 }

--- a/client/src/config.schema.json
+++ b/client/src/config.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/pw-mini-inzynierka/voting-dapp/client/src/config.schema.json",
+    "title": "Config",
+    "description": "Application config",
+    "type": "object",
+    "properties": {
+        "managerContractAddress": {
+            "description": "Manager Contract's address",
+            "type": "string",
+            "minLength": 42,
+            "maxLength": 42
+        },
+        "network": {
+            "description": "Network name",
+            "type": "string",
+            "enum": ["main", "ropsten", "rinkeby", "kovan", "private"]
+        }
+    },
+    "required": ["managerContractAddress", "network"]
+}


### PR DESCRIPTION
Application should be defined to work in one network, as we provide only one address for root ManagerContract. Network type check is introduced in `App.tsx`.

This PR changes the config file contents. It's also renamed to `config.json` (from `managerContract.config.json`).
JSON schema is provided.
