### PR TITLE
fix deadline validation

### DIFF
--- a/client/src/components/createVote/CreateVoteForm.tsx
+++ b/client/src/components/createVote/CreateVoteForm.tsx
@@ -466,12 +466,14 @@ export default class CreateVoteForm extends Component<ICreateVoteFormProps, ICre
     if (!isVotingEndDateTimeValid(this.state.voteDatesProps.endDateTime)) {
       this.setState((state) => {
         return {
+          submitFailed: true,
           voteDatesProps: {
             ...state.voteDatesProps,
             valid: false,
           },
         };
       });
+      return; // setState not updating state fast enough and control flow goes straight to setSubmitData call
     }
 
     if (

--- a/client/src/components/createVote/VoteDates.tsx
+++ b/client/src/components/createVote/VoteDates.tsx
@@ -53,7 +53,7 @@ export default class VoteDates extends Component<IVoteDatesProps> {
               </FormGroup>
             </Col>
             <Col md={6}>
-              <FormGroup validationState={isVotingEndDateTimeValid(this.props.endDateTime) ? null : "error"}>
+              <FormGroup validationState={this.props.valid ? null : "error"}>
                 <HelpBlock>Time</HelpBlock>
                 <Datetime
                   inputProps={{ id: "voteTimeEnd" }}


### PR DESCRIPTION
### Fixed deadline validation bug

Steps to reproduce:
1. Reject a valid transaction
1. Return to pre-filled form
1. Wait until deadline is not valid
1. Click on submit button

Expected behaviour: Validation error
Actual behaviour: Metamask pop-up appears


Additionally, this commit recuded the number of `#isVotingEndDateTimeValid` calls.
It was called every at every `#render`. So, actually, deadline was being validated every time anything was modified.
Now `#render` only checks a boolean variable, so `#isVotingEndDateTimeValid` is called only when user changes the deadline and when they try to submit the form.